### PR TITLE
feat: CLI 설정 파일 로더 동적모듈 감지기능 추가

### DIFF
--- a/apps/my-playground/CHANGELOG.md
+++ b/apps/my-playground/CHANGELOG.md
@@ -1,5 +1,12 @@
 # my-playground
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @mash-up-web-toolkit/command@0.0.11
+
 ## 0.1.5
 
 ### Patch Changes

--- a/apps/my-playground/package.json
+++ b/apps/my-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-playground",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/packages/cli/command/CHANGELOG.md
+++ b/packages/cli/command/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mash-up-web-toolkit/command
 
+## 0.0.11
+
+### Patch Changes
+
+- 설정 파일 로드 시 동적 모듈 형식 감지 기능 추가
+- Updated dependencies
+  - @mash-up-web-toolkit/generate-config@0.0.6
+
 ## 0.0.10
 
 ### Patch Changes

--- a/packages/cli/command/package.json
+++ b/packages/cli/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mash-up-web-toolkit/command",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "mash-up-web-toolkit command line interface",
   "author": "brightbong92",
   "license": "MIT",
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@mash-up-web-toolkit/generate-api": "0.0.9",
-    "@mash-up-web-toolkit/generate-config": "0.0.5",
+    "@mash-up-web-toolkit/generate-config": "0.0.6",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
     "esbuild": "^0.25.2",

--- a/packages/cli/command/src/config/index.ts
+++ b/packages/cli/command/src/config/index.ts
@@ -5,6 +5,25 @@ import { build } from "esbuild";
 import { MashupConfig } from "@/types/types.js";
 
 /**
+ * package.json의 type 필드를 확인하여 format을 결정하는 함수
+ */
+function determineFormat(): "esm" | "cjs" {
+  const cwd = process.cwd();
+  const packageJsonPath = path.resolve(cwd, "package.json");
+
+  try {
+    if (fs.existsSync(packageJsonPath)) {
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+      return packageJson.type === "module" ? "esm" : "cjs";
+    }
+  } catch (error) {
+    console.warn("⚠️ package.json 읽기 실패, 기본값 cjs 사용:", error);
+  }
+
+  return "cjs"; // 기본값
+}
+
+/**
  * 설정 파일을 로드하는 함수
  */
 export async function loadConfig(): Promise<MashupConfig> {
@@ -26,7 +45,7 @@ export async function loadConfig(): Promise<MashupConfig> {
           bundle: true,
           write: true, // 파일에 실제로 쓰기
           platform: "node",
-          format: "cjs",
+          format: determineFormat(),
           outfile: outFile,
         });
 
@@ -41,7 +60,9 @@ export async function loadConfig(): Promise<MashupConfig> {
         // 임시 파일 정리
         try {
           fs.rmSync(outDir, { recursive: true });
-        } catch (e) {}
+        } catch (e) {
+          throw new Error(`${outFile} 파일을 삭제하는데 실패했습니다. ${e}`);
+        }
 
         // 타입 검증
         if (typeof config !== "object" || config === null) {

--- a/packages/cli/generate-config/CHANGELOG.md
+++ b/packages/cli/generate-config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mash-up-web-toolkit/generate-config
 
+## 0.0.6
+
+### Patch Changes
+
+- 설정 파일 로드 시 동적 모듈 형식 감지 기능 추가
+
 ## 0.0.5
 
 ### Patch Changes

--- a/packages/cli/generate-config/package.json
+++ b/packages/cli/generate-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mash-up-web-toolkit/generate-config",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Create config for @mash-up-web-toolkit/command",
   "author": "brightbong92",
   "license": "MIT",

--- a/packages/cli/generate-config/src/config/template.ts
+++ b/packages/cli/generate-config/src/config/template.ts
@@ -1,4 +1,4 @@
-export const configTemplate = `import { MashupConfig } from '@mash-up-web-toolkit/command';
+export const configTemplate = `import type { MashupConfig } from '@mash-up-web-toolkit/command';
 
 const config: MashupConfig = {
   "gen:api": {


### PR DESCRIPTION
<!--
Overview: 작업한 내용에 대해서 작성합니다. 예: "Button 컴포넌트 스타일 및 인터랙션 추가"
Package Scope: @mash-up-web-toolkit/{scope} 형식으로 작성해주세요. 전체 변경일 경우 @mash-up-web-toolkit
Checklist: PR 올리기 전 점검 항목입니다. [x]로 체크해주세요.
-->

# Overview

<!-- 작업한 내용을 요약해주세요. 예: "툴킷 공통 ESLint 설정 추가 및 배포 설정 구성" -->

CLI 설정 파일 로더에 동적 모듈 형식 감지 기능을 추가하여 다양한 모듈 시스템 프로젝트에서 설정 파일을 자동으로 인식하도록 개선했습니다.

## 주요변경사항
- determineFormat() 함수 추가로 package.json의 type 필드 확인
- type: "module"이 있으면 esm, 없으면 cjs 형식으로 번들링
- ESM과 CommonJS 프로젝트 모두 자동 지원
- 임시 파일 삭제 실패 시 명확한 에러 메시지 제공
- 프로젝트의 실제 모듈 시스템과 일치하는 설정 파일 로드

## Package Scope

<!-- 예: @mash-up-web-toolkit/button, @mash-up-web-toolkit/form 등 작업한 패키지 범위를 명시해주세요. 전역이면 @mash-up-web-toolkit -->

`@mash-up-web-toolkit/cli`

## Checklist

<!-- 각 항목을 확인하고 [x]로 체크해주세요 -->

<!-- 예: main, develop 등 적절한 브랜치로 향하고 있는지 -->
- [x] Merge 할 브랜치가 올바른가요?
<!-- console.log, 주석, dead code 등 -->
- [x] 불필요한 코드는 제거했나요?
<!-- 단위 테스트가 있다면 작성 및 통과 확인 -->
- [ ] 테스트 작성 및 통과했나요?
