### PR TITLE
feat: Add generate-api config property 

### DIFF
--- a/apps/my-playground/CHANGELOG.md
+++ b/apps/my-playground/CHANGELOG.md
@@ -1,5 +1,12 @@
 # my-playground
 
+## 0.1.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @mash-up-web-toolkit/command@0.0.14
+
 ## 0.1.8
 
 ### Patch Changes

--- a/apps/my-playground/mashup.config.ts
+++ b/apps/my-playground/mashup.config.ts
@@ -17,6 +17,8 @@ const config: MashupConfig = {
      * @description fetch 또는 axios 인스턴스 경로
      */
     instancePath: "@/configs/axios/instance",
+
+    httpClientRewrite: true,
   },
 };
 

--- a/apps/my-playground/package.json
+++ b/apps/my-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-playground",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/packages/cli/command/CHANGELOG.md
+++ b/packages/cli/command/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @mash-up-web-toolkit/command
 
+## 0.0.14
+
+### Patch Changes
+
+- writeGeneratedApi 함수에 httpClientRewrite 옵션을 추가했습니다.
+- Updated dependencies
+  - @mash-up-web-toolkit/generate-config@0.0.7
+  - @mash-up-web-toolkit/generate-api@0.0.12
+
 ## 0.0.13
 
 ### Patch Changes

--- a/packages/cli/command/package.json
+++ b/packages/cli/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mash-up-web-toolkit/command",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "mash-up-web-toolkit command line interface",
   "author": "brightbong92",
   "license": "MIT",
@@ -37,8 +37,8 @@
     "dist"
   ],
   "dependencies": {
-    "@mash-up-web-toolkit/generate-api": "0.0.11",
-    "@mash-up-web-toolkit/generate-config": "0.0.6",
+    "@mash-up-web-toolkit/generate-api": "0.0.12",
+    "@mash-up-web-toolkit/generate-config": "0.0.7",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
     "esbuild": "^0.25.2",

--- a/packages/cli/command/src/types/types.ts
+++ b/packages/cli/command/src/types/types.ts
@@ -1,13 +1,31 @@
 export interface GenApiConfig {
+  /**
+   * @description 생성될 파일의 경로
+   */
   output: string;
+
+  /**
+   * @description 생성할 API의 주소
+   */
   url: string;
+
+  /**
+   * @description 생성할 API의 입력 파일
+   */
   input?: string;
-  httpClientType?: "axios" | "fetch";
+
+  /**
+   * @description fetch 또는 axios 인스턴스 경로
+   */
   instancePath?: string;
+
+  /**
+   * @description httpClient 덮어쓰기 여부 (true: 덮어쓰기, false: 기존 파일 사용)
+   */
+  httpClientRewrite?: boolean;
 }
 
 export interface MashupConfig {
   "gen:api": GenApiConfig;
-
   [key: string]: any;
 }

--- a/packages/cli/generate-api/CHANGELOG.md
+++ b/packages/cli/generate-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mash-up-web-toolkit/generate-api
 
+## 0.0.12
+
+### Patch Changes
+
+- writeGeneratedApi 함수에 httpClientRewrite 옵션을 추가했습니다.
+
 ## 0.0.11
 
 ### Patch Changes

--- a/packages/cli/generate-api/package.json
+++ b/packages/cli/generate-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mash-up-web-toolkit/generate-api",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "API client code generator used by @mash-up-web-toolkit/command",
   "type": "module",
   "author": "brightbong92",

--- a/packages/cli/generate-api/src/generator/generator.ts
+++ b/packages/cli/generate-api/src/generator/generator.ts
@@ -15,10 +15,15 @@ export const generateSwaggerApi = async (
     });
 };
 
-export const writeGeneratedApi = async (
-  result: Awaited<ReturnType<typeof generateApi>>,
-  outputPath: string
-) => {
+export const writeGeneratedApi = async ({
+  result,
+  outputPath,
+  httpClientRewrite,
+}: {
+  result: Awaited<ReturnType<typeof generateApi>>;
+  outputPath: string;
+  httpClientRewrite?: boolean;
+}) => {
   const { files } = await result;
   files.forEach((element) => {
     const { fileName, fileContent } = element;
@@ -32,7 +37,12 @@ export const writeGeneratedApi = async (
     const folderPath = getFolderPath(outputPath, fileName);
 
     fs.mkdirSync(folderPath, { recursive: true });
-    if (fileName === "http-client" || fileName === "data-contracts") {
+    if (fileName === "http-client") {
+      if (httpClientRewrite) {
+        createFile(path.resolve(folderPath, "index.ts"), fileContent);
+      }
+      return;
+    } else if (fileName === "data-contracts") {
       createFile(path.resolve(folderPath, "index.ts"), fileContent);
       return;
     }
@@ -64,7 +74,7 @@ const commentTemplate = `/* eslint-disable */
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
  * ##                                                           ##
- * ## AUTHOR: brightbong                                        ##
+ * ## AUTHOR: brightbong92                                      ##
  * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
  * ---------------------------------------------------------------
  */

--- a/packages/cli/generate-api/src/index.ts
+++ b/packages/cli/generate-api/src/index.ts
@@ -8,6 +8,7 @@ import { generateApi } from "swagger-typescript-api";
 import { generateConfig } from "./configs/generate-config.js";
 
 export type GenerateApiParamsType = {
+  httpClientRewrite?: boolean;
   httpClientType: "fetch" | "axios";
   instancePath?: string;
   url: string;
@@ -41,7 +42,11 @@ export const runGenerateApi = async (params: GenerateApiParamsType) => {
     },
   });
 
-  await writeGeneratedApi(result, path.resolve(process.cwd(), output))
+  await writeGeneratedApi({
+    result,
+    outputPath: path.resolve(process.cwd(), output),
+    httpClientRewrite: params.httpClientRewrite,
+  })
     .then(() => {
       console.log("✅ API 생성 완료! 🌈✨");
       process.exit(0);

--- a/packages/cli/generate-api/src/templates/swagger/custom-axios/api.eta
+++ b/packages/cli/generate-api/src/templates/swagger/custom-axios/api.eta
@@ -22,7 +22,7 @@ import { <%=instanceName%> } from './<%=pascalCase(route.moduleName)%>.api';
 import instance from "<%~ instancePath%>";
 import { HttpClient, RequestParams, ContentType, HttpResponse } from "../@<%~ config.fileNames.httpClient %>";
 <% if (dataContracts.length) { %>
-import { <%~ dataContracts.join(", ") %> } from "../@types"
+import type { <%~ dataContracts.join(", ") %> } from "../@types"
 <% } %>
 
 export class <%= apiClassName %><SecurityDataType=unknown><% if (!config.singleHttpClient) { %> extends HttpClient<SecurityDataType> <% } %> {

--- a/packages/cli/generate-api/src/templates/swagger/custom-fetch/api.eta
+++ b/packages/cli/generate-api/src/templates/swagger/custom-fetch/api.eta
@@ -21,7 +21,7 @@ import { <%=instanceName%> } from './<%=pascalCase(route.moduleName)%>.api';
 import customFetch from "<%~ instancePath%>";
 import { HttpClient, RequestParams, ContentType, HttpResponse } from "../@<%~ config.fileNames.httpClient %>";
 <% if (dataContracts.length) { %>
-import { <%~ dataContracts.join(", ") %> } from "../@types"
+import type { <%~ dataContracts.join(", ") %> } from "../@types"
 <% } %>
 
 export class <%= apiClassName %><SecurityDataType=unknown><% if (!config.singleHttpClient) { %> extends HttpClient<SecurityDataType> <% } %> {

--- a/packages/cli/generate-config/CHANGELOG.md
+++ b/packages/cli/generate-config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mash-up-web-toolkit/generate-config
 
+## 0.0.7
+
+### Patch Changes
+
+- writeGeneratedApi 함수에 httpClientRewrite 옵션을 추가했습니다.
+
 ## 0.0.6
 
 ### Patch Changes

--- a/packages/cli/generate-config/package.json
+++ b/packages/cli/generate-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mash-up-web-toolkit/generate-config",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Create config for @mash-up-web-toolkit/command",
   "author": "brightbong92",
   "license": "MIT",

--- a/packages/cli/generate-config/src/config/template.ts
+++ b/packages/cli/generate-config/src/config/template.ts
@@ -16,6 +16,11 @@ const config: MashupConfig = {
      * @description fetch 또는 axios 인스턴스 경로
      */
     instancePath: "@/configs/axios/instance",
+
+    /**
+     * @description httpClient 덮어쓰기 여부 (true: 덮어쓰기, false: 기존 파일 사용)
+     */
+    httpClientRewrite: true,
   },
 };
 


### PR DESCRIPTION
<!--
Overview: 작업한 내용에 대해서 작성합니다. 예: "Button 컴포넌트 스타일 및 인터랙션 추가"
Package Scope: @mash-up-web-toolkit/{scope} 형식으로 작성해주세요. 전체 변경일 경우 @mash-up-web-toolkit
Checklist: PR 올리기 전 점검 항목입니다. [x]로 체크해주세요.
-->

# Overview

<!-- 작업한 내용을 요약해주세요. 예: "툴킷 공통 ESLint 설정 추가 및 배포 설정 구성" -->

- httpClientRewrite 옵션을  추가했어요. 
  - 이걸 이용해 @http-client/index.ts파일의 덮어쓰기를 방지할수 있어요.
- api.eta 템플릿을 보완했어요.
  - import시 type 키워드를 추가했어요.

## Package Scope

<!-- 예: @mash-up-web-toolkit/button, @mash-up-web-toolkit/form 등 작업한 패키지 범위를 명시해주세요. 전역이면 @mash-up-web-toolkit -->

`@mash-up-web-toolkit/command`
`@mash-up-web-toolkit/generate-api`
`@mash-up-web-toolkit/generate-config`

## Checklist

<!-- 각 항목을 확인하고 [x]로 체크해주세요 -->

<!-- 예: main, develop 등 적절한 브랜치로 향하고 있는지 -->
- [ ] Merge 할 브랜치가 올바른가요?
<!-- console.log, 주석, dead code 등 -->
- [ ] 불필요한 코드는 제거했나요?
<!-- 단위 테스트가 있다면 작성 및 통과 확인 -->
- [ ] 테스트 작성 및 통과했나요?
